### PR TITLE
Export PYTHONPATH=. in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,8 @@ KSY_OPTIONS = --outdir RigolWFM
 
 YAML_LINT_OPTIONS = -d "{extends: default, rules: {document-start: disable}}"
 
+export PYTHONPATH ?= .
+
 all: $(python_parsers)
 
 RigolWFM/wfm1000d.py: ksy/wfm1000d.ksy


### PR DESCRIPTION
This way, tests can run without having the user explicitly add '.' to the python path. 

This is a quick fix, but it might also be good to think about having relative imports instead. But I tried that, and just got confused when python complained: `from . import wfm4000` led to `ImportError: attempted relative import with no known parent package`, despite there being an `__init__.py` in `RigolWFM`...

Btw, you might want to consider opening this repository again as its own thing instead of a fork, so users can open new issues here - that's not enabled for forks, and the repo has a fair amount of new stuff that we can't exactly report to "upstream".